### PR TITLE
댓글 생성 로직 수정

### DIFF
--- a/src/main/java/com/pinterest/domain/Article.java
+++ b/src/main/java/com/pinterest/domain/Article.java
@@ -27,6 +27,7 @@ public class Article extends BaseEntity {
     @JoinColumn(name = "board_id")
     private Board board;
 
+    @OrderBy("createdAt DESC")
     @OneToMany(mappedBy = "article", cascade = CascadeType.ALL)
     private List<Comment> comments = new ArrayList<>();
 

--- a/src/main/java/com/pinterest/service/CommentService.java
+++ b/src/main/java/com/pinterest/service/CommentService.java
@@ -1,7 +1,6 @@
 package com.pinterest.service;
 
 import com.pinterest.domain.Article;
-import com.pinterest.domain.Comment;
 import com.pinterest.domain.Member;
 import com.pinterest.dto.CommentDto;
 import com.pinterest.repository.ArticleRepository;
@@ -39,22 +38,11 @@ public class CommentService {
     public void saveComment(CommentDto dto) {
         try {
             Article article = articleRepository.getReferenceById(dto.getArticleId());
-            Member member = memberRepository.getReferenceById(dto.getMemberDto().getId());
+            Member member = memberRepository.findByEmail(dto.getMemberDto().getEmail())
+                    .orElseThrow(() -> new EntityNotFoundException("회원 정보가 없습니다."));
             commentRepository.save(dto.toEntity(article, member));
         } catch (EntityNotFoundException e) {
             log.warn("댓글 저장 실패. 댓글의 게시글을 찾을 수 없습니다.");
-        }
-    }
-
-    @Transactional
-    public void updateComment(CommentDto dto) {
-        try {
-            Comment comment = commentRepository.getReferenceById(dto.getId());
-            if (dto.getContent() != null) {
-                comment.setContent(dto.getContent());
-            }
-        } catch (EntityNotFoundException e) {
-            log.warn("댓글 업데이트 실패. 댓글을 찾을 수 없습니다.");
         }
     }
 

--- a/src/main/resources/templates/articles/detail.html
+++ b/src/main/resources/templates/articles/detail.html
@@ -32,17 +32,19 @@
       article 본문
     </div>
 
-    {% if target_article.writer == user %}
-    <div class="py-4">
-      <form th:action="@{/articles/{articleId}/delete(articleId=${article.id})}" th:method="post">
-        <a th:href="@{/articles/{articleId}/form(articleId=${article.id})}" class="btn btn-primary rounded-pill col-3">
-          수정
-        </a>
-        <button type="submit" class="btn btn-danger rounded-pill col-3">삭제</button>
-      </form>
-    </div>
+    <th:block
+        th:if="${#authorization.expression('isAuthenticated()')} and ${article.getMemberDto().getEmail()} == ${#authentication.name}">
+      <div class="py-4">
+        <form th:action="@{/articles/{articleId}/delete(articleId=${article.id})}" th:method="post">
+          <a th:href="@{/articles/{articleId}/form(articleId=${article.id})}"
+             class="btn btn-primary rounded-pill col-3">
+            수정
+          </a>
+          <button type="submit" class="btn btn-danger rounded-pill col-3">삭제</button>
+        </form>
+      </div>
+    </th:block>
 
-    {% endif %}
     <hr>
 
     <!--댓글 생성-->
@@ -77,13 +79,16 @@
           </div>
           <span th:text="${comment.content}">댓글 내용</span>
           <div style="margin:1rem 0;"></div>
-          {% if comment.writer == user %}
-          <div style="text-align:right">
-            <button type="submit" class="btn btn-danger rounded-pill px-4">
-              삭제
-            </button>
-          </div>
-          {% endif %}
+
+          <th:block
+              th:if="${#authorization.expression('isAuthenticated()')} and ${comment.getMemberDto().getEmail()} == ${#authentication.name}">
+            <div style="text-align:right">
+              <button type="submit" class="btn btn-danger rounded-pill px-4">
+                삭제
+              </button>
+            </div>
+          </th:block>
+
         </form>
       </div>
     </th:block>

--- a/src/test/java/com/pinterest/service/CommentServiceTest.java
+++ b/src/test/java/com/pinterest/service/CommentServiceTest.java
@@ -19,6 +19,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import javax.persistence.EntityNotFoundException;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -64,7 +65,7 @@ class CommentServiceTest {
         // Given
         CommentDto dto = createCommentDto("comment");
         given(articleRepository.getReferenceById(dto.getArticleId())).willReturn(createArticle());
-        given(memberRepository.getReferenceById(dto.getMemberDto().getId())).willReturn(createMember());
+        given(memberRepository.findByEmail(dto.getMemberDto().getEmail())).willReturn(Optional.of(createMember()));
         given(commentRepository.save(any(Comment.class))).willReturn(null);
 
         // When
@@ -72,7 +73,7 @@ class CommentServiceTest {
 
         // Then
         then(articleRepository).should().getReferenceById(dto.getArticleId());
-        then(memberRepository).should().getReferenceById(dto.getMemberDto().getId());
+        then(memberRepository).should().findByEmail(dto.getMemberDto().getEmail());
         then(commentRepository).should().save(any(Comment.class));
     }
 
@@ -89,40 +90,6 @@ class CommentServiceTest {
         // Then
         then(articleRepository).should().getReferenceById(dto.getArticleId());
         then(commentRepository).shouldHaveNoInteractions();
-    }
-
-    @Test
-    @DisplayName("댓글 수정 정보를 입력하면, 댓글을 수정한다.")
-    void givenCommentInfo_whenUpdatingComment_thenUpdatesComment() {
-        // Given
-        String oldContent = "old comment";
-        String updatedContent = "new comment";
-        Comment comment = createComment(oldContent);
-        CommentDto dto = createCommentDto(updatedContent);
-        given(commentRepository.getReferenceById(dto.getId())).willReturn(comment);
-
-        // When
-        sut.updateComment(dto);
-
-        // Then
-        assertThat(comment.getContent())
-                .isNotEqualTo(oldContent)
-                .isEqualTo(updatedContent);
-        then(commentRepository).should().getReferenceById(dto.getId());
-    }
-
-    @Test
-    @DisplayName("없는 댓글 정보를 수정하려고 하면, 경고 로그를 찍고 아무것도 안한다.")
-    void givenNoneExistentComment_whenUpdatingComment_thenLogsWarningAndDoesNoting() {
-        // Given
-        CommentDto dto = createCommentDto("comment");
-        given(commentRepository.getReferenceById(dto.getId())).willThrow(EntityNotFoundException.class);
-
-        // When
-        sut.updateComment(dto);
-
-        // Then
-        then(commentRepository).should().getReferenceById(dto.getId());
     }
 
     @Test


### PR DESCRIPTION
댓글 생성 로직을 수정함.
댓글 수정 기능은 구현할 필요가 없어서 삭제함.
댓글 리스트 표출 시 최근 생성된 기준으로 변경함.

This is closes #37 