### PR TITLE
AWS S3 파일 저장, 삭제 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,8 @@ dependencies {
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'
     implementation 'com.google.code.findbugs:jsr305:3.0.2'
 
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
     testImplementation 'org.projectlombok:lombok:1.18.26'
     compileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.22'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'
+    implementation 'com.google.code.findbugs:jsr305:3.0.2'
 
     testImplementation 'org.projectlombok:lombok:1.18.26'
     compileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.22'

--- a/src/main/java/com/pinterest/config/S3Config.java
+++ b/src/main/java/com/pinterest/config/S3Config.java
@@ -1,0 +1,32 @@
+package com.pinterest.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region)
+                .build();
+    }
+}

--- a/src/main/java/com/pinterest/config/SecurityConfig.java
+++ b/src/main/java/com/pinterest/config/SecurityConfig.java
@@ -29,6 +29,7 @@ public class SecurityConfig {
                                 new AntPathRequestMatcher("/articles"),
                                 new AntPathRequestMatcher("/image/**"),
                                 new AntPathRequestMatcher("/attach/**"),
+                                new AntPathRequestMatcher("/s3/**"),
                                 new AntPathRequestMatcher("/"))
                         .permitAll()
                         .anyRequest().authenticated()

--- a/src/main/java/com/pinterest/controller/FileController.java
+++ b/src/main/java/com/pinterest/controller/FileController.java
@@ -1,14 +1,13 @@
 package com.pinterest.controller;
 
 import com.pinterest.service.FileService;
-import com.pinterest.service.S3ImageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 import java.net.MalformedURLException;
 
@@ -17,23 +16,10 @@ import java.net.MalformedURLException;
 public class FileController {
 
     private final FileService fileService;
-    private final S3ImageService s3ImageService;
 
     @GetMapping("/attach/{filename}")
     @ResponseBody
     public Resource getImage(@PathVariable String filename) throws MalformedURLException {
         return new UrlResource("file:" + fileService.getFullPath(filename));
-    }
-
-    @PostMapping("/s3/upload")
-    public ResponseEntity<?> s3Upload(@RequestPart(value = "image", required = false) MultipartFile image) {
-        String profileImage = s3ImageService.upload(image);
-        return ResponseEntity.ok(profileImage);
-    }
-
-    @GetMapping("/s3/delete")
-    public ResponseEntity<?> s3delete(@RequestParam String addr) {
-        s3ImageService.deleteImageFromS3(addr);
-        return ResponseEntity.ok(null);
     }
 }

--- a/src/main/java/com/pinterest/controller/FileController.java
+++ b/src/main/java/com/pinterest/controller/FileController.java
@@ -1,13 +1,14 @@
 package com.pinterest.controller;
 
 import com.pinterest.service.FileService;
+import com.pinterest.service.S3ImageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.net.MalformedURLException;
 
@@ -16,10 +17,23 @@ import java.net.MalformedURLException;
 public class FileController {
 
     private final FileService fileService;
+    private final S3ImageService s3ImageService;
 
     @GetMapping("/attach/{filename}")
     @ResponseBody
     public Resource getImage(@PathVariable String filename) throws MalformedURLException {
         return new UrlResource("file:" + fileService.getFullPath(filename));
+    }
+
+    @PostMapping("/s3/upload")
+    public ResponseEntity<?> s3Upload(@RequestPart(value = "image", required = false) MultipartFile image) {
+        String profileImage = s3ImageService.upload(image);
+        return ResponseEntity.ok(profileImage);
+    }
+
+    @GetMapping("/s3/delete")
+    public ResponseEntity<?> s3delete(@RequestParam String addr) {
+        s3ImageService.deleteImageFromS3(addr);
+        return ResponseEntity.ok(null);
     }
 }

--- a/src/main/java/com/pinterest/domain/Article.java
+++ b/src/main/java/com/pinterest/domain/Article.java
@@ -39,7 +39,7 @@ public class Article extends BaseEntity {
     @Column(nullable = false, length = 2000)
     private String content;
 
-    @OneToOne
+    @OneToOne(orphanRemoval = true)
     @JoinColumn(name = "file_id")
     private FileEntity file;
 

--- a/src/main/java/com/pinterest/domain/ArticleLike.java
+++ b/src/main/java/com/pinterest/domain/ArticleLike.java
@@ -2,6 +2,8 @@ package com.pinterest.domain;
 
 import lombok.Getter;
 import lombok.ToString;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import javax.persistence.*;
 
@@ -21,10 +23,12 @@ public class ArticleLike {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "board_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Board board;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "article_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Article article;
 
     protected ArticleLike() {

--- a/src/main/java/com/pinterest/domain/FileEntity.java
+++ b/src/main/java/com/pinterest/domain/FileEntity.java
@@ -1,12 +1,14 @@
 package com.pinterest.domain;
 
 import lombok.Getter;
+import lombok.ToString;
 
 import javax.persistence.*;
 
 @Entity
 @Table(name = "file")
 @Getter
+@ToString
 public class FileEntity {
 
     @Id
@@ -15,7 +17,9 @@ public class FileEntity {
     private Long id;
 
     private String fileName;
+    @Column(length = 2000)
     private String savedName;
+    @Column(length = 2000)
     private String savedPath;
 
     protected FileEntity() {

--- a/src/main/java/com/pinterest/domain/FileEntity.java
+++ b/src/main/java/com/pinterest/domain/FileEntity.java
@@ -16,6 +16,7 @@ public class FileEntity {
     @Column(name = "file_id")
     private Long id;
 
+    @Column(length = 2000)
     private String fileName;
     @Column(length = 2000)
     private String savedName;

--- a/src/main/java/com/pinterest/domain/Follow.java
+++ b/src/main/java/com/pinterest/domain/Follow.java
@@ -7,7 +7,7 @@ import javax.persistence.*;
 
 @Entity
 @Getter
-@ToString(exclude = "member")
+@ToString(exclude = {"fromMember", "toMember"})
 public class Follow {
 
     @Id

--- a/src/main/java/com/pinterest/domain/Member.java
+++ b/src/main/java/com/pinterest/domain/Member.java
@@ -33,7 +33,7 @@ public class Member extends BaseEntity {
     @Column(length = 2000)
     private String image;
 
-    @OneToOne
+    @OneToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "file_id")
     private FileEntity file;
 

--- a/src/main/java/com/pinterest/dto/ArticleDto.java
+++ b/src/main/java/com/pinterest/dto/ArticleDto.java
@@ -28,6 +28,10 @@ public class ArticleDto {
         return new ArticleDto(null, boardId, memberDto, title, content, hashtag, null, null);
     }
 
+    public static ArticleDto of(Long boardId, MemberDto memberDto, String title, String content, String hashtag, String image) {
+        return new ArticleDto(null, boardId, memberDto, title, content, hashtag, image, null);
+    }
+
     // entity -> dto
     public static ArticleDto from(Article entity) {
         return new ArticleDto(

--- a/src/main/java/com/pinterest/error/PinterestException.java
+++ b/src/main/java/com/pinterest/error/PinterestException.java
@@ -1,0 +1,12 @@
+package com.pinterest.error;
+
+public class PinterestException extends RuntimeException {
+
+    PinterestException() {
+
+    }
+
+    public PinterestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/pinterest/repository/BoardRepository.java
+++ b/src/main/java/com/pinterest/repository/BoardRepository.java
@@ -14,5 +14,5 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
 
     void deleteByIdAndMember_Email(Long boardId, String email);
 
-    Optional<Board> findByTitle(String title);
+    Optional<Board> findByMemberIdAndTitle(Long memberId, String title);
 }

--- a/src/main/java/com/pinterest/service/ArticleService.java
+++ b/src/main/java/com/pinterest/service/ArticleService.java
@@ -1,5 +1,6 @@
 package com.pinterest.service;
 
+import com.pinterest.domain.Article;
 import com.pinterest.domain.Board;
 import com.pinterest.domain.FileEntity;
 import com.pinterest.domain.Member;
@@ -63,6 +64,9 @@ public class ArticleService {
 
     @Transactional
     public void deleteArticle(Long articleId, String email) {
-        articleRepository.deleteByIdAndMember_Email(articleId, email);
+        Article article = articleRepository.findById(articleId)
+                .orElseThrow(() -> new EntityNotFoundException("핀이 없습니다."));
+        fileService.deleteImage(article.getFile().getSavedName());
+        articleRepository.delete(article);
     }
 }

--- a/src/main/java/com/pinterest/service/ArticleService.java
+++ b/src/main/java/com/pinterest/service/ArticleService.java
@@ -55,7 +55,7 @@ public class ArticleService {
         Member member = memberRepository.findByEmail(dto.getMemberDto().getEmail())
                 .orElseThrow(() -> new EntityNotFoundException("회원 정보가 없습니다."));
 
-        FileEntity fileEntity = fileService.saveFile(file);
+        FileEntity fileEntity = fileService.upload(file);
 
         Board board = boardRepository.getReferenceById(dto.getBoardId());
         articleRepository.save(dto.toEntity(member, board, fileEntity));

--- a/src/main/java/com/pinterest/service/BoardService.java
+++ b/src/main/java/com/pinterest/service/BoardService.java
@@ -79,7 +79,7 @@ public class BoardService {
     }
 
     private void boardTitleDuplicated(BoardDto dto) {
-        Optional<Board> board = boardRepository.findByTitle(dto.getTitle());
+        Optional<Board> board = boardRepository.findByMemberIdAndTitle(dto.getMemberDto().getId(), dto.getTitle());
         if (board.isPresent()) {
             throw new EntityExistsException("이미 존재하는 보드 이름 입니다.");
         }

--- a/src/main/java/com/pinterest/service/FileService.java
+++ b/src/main/java/com/pinterest/service/FileService.java
@@ -8,4 +8,6 @@ public interface FileService {
     FileEntity upload(MultipartFile image);
 
     String getFullPath(String filename);
+
+    void deleteImage(String filename);
 }

--- a/src/main/java/com/pinterest/service/FileService.java
+++ b/src/main/java/com/pinterest/service/FileService.java
@@ -1,50 +1,11 @@
 package com.pinterest.service;
 
 import com.pinterest.domain.FileEntity;
-import com.pinterest.repository.FileRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.UUID;
+public interface FileService {
 
-@Service
-@RequiredArgsConstructor
-@Transactional(readOnly = true)
-public class FileService {
+    FileEntity upload(MultipartFile image);
 
-    @Value("${file.dir}")
-    private String fileRootDir;
-    private final FileRepository fileRepository;
-
-    public String getFullPath(String fileName) {
-        return fileRootDir + fileName;
-    }
-
-    @Transactional
-    public FileEntity saveFile(MultipartFile file) {
-        if (file.isEmpty()) {
-            return null;
-        }
-
-        String fileName = file.getOriginalFilename();
-        String uuid = UUID.randomUUID().toString();
-        String extension = fileName.substring(fileName.lastIndexOf("."));
-        String savedName = uuid + extension;
-        String savedPath = fileRootDir + savedName;
-
-        try {
-            file.transferTo(new File(savedPath));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-
-        FileEntity entity = FileEntity.of(fileName, savedName, savedPath);
-
-        return fileRepository.save(entity);
-    }
+    String getFullPath(String filename);
 }

--- a/src/main/java/com/pinterest/service/FileServiceImpl.java
+++ b/src/main/java/com/pinterest/service/FileServiceImpl.java
@@ -1,0 +1,53 @@
+package com.pinterest.service;
+
+import com.pinterest.domain.FileEntity;
+import com.pinterest.repository.FileRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+
+@Service
+@Profile("local")
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FileServiceImpl implements FileService {
+
+    @Value("${file.dir}")
+    private String fileRootDir;
+    private final FileRepository fileRepository;
+
+    public String getFullPath(String fileName) {
+        return fileRootDir + fileName;
+    }
+
+    @Override
+    @Transactional
+    public FileEntity upload(MultipartFile file) {
+        if (file.isEmpty()) {
+            return null;
+        }
+
+        String fileName = file.getOriginalFilename();
+        String uuid = UUID.randomUUID().toString();
+        String extension = fileName.substring(fileName.lastIndexOf("."));
+        String savedName = uuid + extension;
+        String savedPath = fileRootDir + savedName;
+
+        try {
+            file.transferTo(new File(savedPath));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        FileEntity entity = FileEntity.of(fileName, savedName, savedPath);
+
+        return fileRepository.save(entity);
+    }
+}

--- a/src/main/java/com/pinterest/service/FileServiceImpl.java
+++ b/src/main/java/com/pinterest/service/FileServiceImpl.java
@@ -11,10 +11,13 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.util.UUID;
 
 @Service
-@Profile("local")
+@Profile("prod")
+//@Profile("local")
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class FileServiceImpl implements FileService {
@@ -49,5 +52,18 @@ public class FileServiceImpl implements FileService {
         FileEntity entity = FileEntity.of(fileName, savedName, savedPath);
 
         return fileRepository.save(entity);
+    }
+
+    @Override
+    public void deleteImage(String filename) {
+        String srcFileName = null;
+
+        try {
+            srcFileName = URLDecoder.decode(filename, "UTF-8");
+            File file = new File(fileRootDir + File.separator + srcFileName);
+            file.delete();
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/src/main/java/com/pinterest/service/ProfileService.java
+++ b/src/main/java/com/pinterest/service/ProfileService.java
@@ -30,7 +30,7 @@ public class ProfileService {
                 if (file.isEmpty()) {
                     member.update(dto.getNickname());
                 } else {
-                    FileEntity fileEntity = fileService.saveFile(file);
+                    FileEntity fileEntity = fileService.upload(file);
                     member.update(dto.getNickname(), fileEntity);
                 }
             }

--- a/src/main/java/com/pinterest/service/S3ImageService.java
+++ b/src/main/java/com/pinterest/service/S3ImageService.java
@@ -1,0 +1,131 @@
+package com.pinterest.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.util.IOUtils;
+import com.pinterest.domain.FileEntity;
+import com.pinterest.dto.FileDto;
+import com.pinterest.error.PinterestException;
+import com.pinterest.repository.FileRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class S3ImageService {
+
+    private final FileRepository fileRepository;
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucketName}")
+    private String bucketName;
+
+    public String upload(MultipartFile image) {
+        if (image.isEmpty() || Objects.isNull(image.getOriginalFilename())) {
+            throw new PinterestException("S3 에러, 파일이 없습니다.");
+        }
+        return this.uploadImage(image);
+    }
+
+    private String uploadImage(MultipartFile image) {
+        this.validateImageFileExtension(image.getOriginalFilename());
+        try {
+            return this.uploadImageToS3(image);
+        } catch (IOException e) {
+            throw new PinterestException("S3 에러, 이미지 업로드 시 에러가 발생하였습니다.");
+        }
+    }
+
+    private void validateImageFileExtension(String filename) {
+        int lastDotIndex = filename.lastIndexOf(".");
+        if (lastDotIndex == -1) {
+            throw new PinterestException("S3 에러, 파일 형식이 잘못되었습니다.");
+        }
+
+        String extension = filename.substring(lastDotIndex + 1).toLowerCase();
+        List<String> allowedExtensionList = Arrays.asList("jpg", "jpeg", "png", "gif");
+
+        if (!allowedExtensionList.contains(extension)) {
+            throw new PinterestException("S3 에러, 파일 형식은 jpg, jpeg, png, gif 이어야 합니다.");
+        }
+    }
+
+    private String uploadImageToS3(MultipartFile image) throws IOException {
+        String originalFilename = image.getOriginalFilename(); //원본 파일 명
+        String extension = originalFilename.substring(originalFilename.lastIndexOf(".")); //확장자 명
+
+        String s3FileName = UUID.randomUUID().toString().substring(0, 10) + originalFilename; //변경된 파일 명
+
+        InputStream is = image.getInputStream();
+        byte[] bytes = IOUtils.toByteArray(is);
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType("image/" + extension);
+        metadata.setContentLength(bytes.length);
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
+        String savedName = null;
+        try {
+            PutObjectRequest putObjectRequest =
+                    new PutObjectRequest(bucketName, s3FileName, byteArrayInputStream, metadata)
+                            .withCannedAcl(CannedAccessControlList.PublicRead);
+            amazonS3.putObject(putObjectRequest); // put image to S3
+
+            savedName = amazonS3.getUrl(bucketName, s3FileName).toString();
+
+        } catch (Exception e) {
+            throw new PinterestException("S3 파일 에러가 발생하였습니다.");
+        } finally {
+            byteArrayInputStream.close();
+            is.close();
+        }
+
+        save(originalFilename, savedName);
+
+        return savedName;
+    }
+
+    @Transactional
+    public void save(String originalFilename, String savedName) {
+        FileEntity entity = FileEntity.of(originalFilename, savedName, "");
+        fileRepository.save(entity);
+    }
+
+    public void deleteImageFromS3(String imageAddress) {
+        String key = getKeyFromImageAddress(imageAddress);
+        try {
+            amazonS3.deleteObject(new DeleteObjectRequest(bucketName, key));
+        } catch (Exception e) {
+            throw new PinterestException("S3 에러, 이미지 삭제 시 오류가 발생하였습니다.");
+        }
+    }
+
+    private String getKeyFromImageAddress(String imageAddress) {
+        try {
+            URL url = new URL(imageAddress);
+            String decodingKey = URLDecoder.decode(url.getPath(), "UTF-8");
+            return decodingKey.substring(1); // 맨 앞의 '/' 제거
+        } catch (MalformedURLException | UnsupportedEncodingException e) {
+            throw new PinterestException("S3 파일 에러가 발생하였습니다.");
+        }
+    }
+}

--- a/src/main/java/com/pinterest/service/S3ImageService.java
+++ b/src/main/java/com/pinterest/service/S3ImageService.java
@@ -30,7 +30,8 @@ import java.util.Objects;
 import java.util.UUID;
 
 @Service
-@Profile("prod")
+@Profile("local")
+//@Profile("prod")
 @RequiredArgsConstructor
 @Slf4j
 public class S3ImageService implements FileService {
@@ -112,7 +113,7 @@ public class S3ImageService implements FileService {
         return fileRepository.save(entity);
     }
 
-    public void deleteImageFromS3(String imageAddress) {
+    public void deleteImage(String imageAddress) {
         String key = getKeyFromImageAddress(imageAddress);
         try {
             amazonS3.deleteObject(new DeleteObjectRequest(bucketName, key));

--- a/src/main/resources/templates/articles/detail.html
+++ b/src/main/resources/templates/articles/detail.html
@@ -7,7 +7,12 @@
 <main>
   <div class="max-w-5xl mx-auto h-auto overflow-hidden my-8 px-6 py-10 bg-white rounded-lg shadow-md grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
     <div class="flex sm:col-span-3 items-center">
-      <img th:src="|/attach/${article.savedName}|" alt="" class="w-68 h-auto object-contain rounded-lg m-auto">
+      <div th:if="${#strings.contains(article.savedName, 'https')}">
+        <img th:src="${article.savedName}" alt="" class="w-68 h-auto object-contain rounded-lg m-auto">
+      </div>
+      <div th:if="!${#strings.contains(article.savedName, 'https')}">
+        <img th:src="|/attach/${article.savedName}|" alt="" class="w-68 h-auto object-contain rounded-lg m-auto">
+      </div>
     </div>
     <div class="sm:col-span-3 flex-auto pl-6 m-4">
       <th:block th:if="${article.getMemberDto().getEmail()} == ${#authentication.name}">

--- a/src/main/resources/templates/base/snippets/article.html
+++ b/src/main/resources/templates/base/snippets/article.html
@@ -5,7 +5,10 @@
   <div class="container">
     <th:block th:each="article: ${articles}">
       <a th:href="@{/articles/{articleId}(articleId=${article.id})}">
-        <div>
+        <div th:if="${#strings.contains(article.image, 'https')}">
+          <img th:src="${article.image}" alt="">
+        </div>
+        <div th:if="!${#strings.contains(article.image, 'https')}">
           <img th:src="|/attach/${article.image}|" alt="">
         </div>
         <h6 class="mt-2" th:text="${article.title}">

--- a/src/main/resources/templates/base/snippets/profile.html
+++ b/src/main/resources/templates/base/snippets/profile.html
@@ -4,7 +4,12 @@
 <th:block th:fragment="profileFragment(profile)">
   <th:block th:if="${profile.savedName == null}">
     <th:block th:if="${profile.image != null and profile.image != ''}">
-      <img th:src="${profile.image}" alt="" class="w-10 h-10 object-cover rounded-full">
+      <div th:if="${#strings.contains(profile.image, 'https')}">
+        <img th:src="${profile.image}" alt="" class="w-10 h-10 object-cover rounded-full">
+      </div>
+      <div th:if="!${#strings.contains(profile.image, 'https')}">
+        <img th:src="|/attach/${profile.image}|" alt="" class="w-10 h-10 object-cover rounded-full">
+      </div>
     </th:block>
     <th:block th:if="${profile.image == null or profile.image == ''}">
       <div class="w-10 h-10 rounded-full inline-flex items-center justify-center bg-gray-200 text-gray-900 text-sm font-bold"
@@ -12,7 +17,12 @@
     </th:block>
   </th:block>
   <th:block th:if="${profile.savedName != null}">
-    <img th:src="|/attach/${profile.savedName}|" alt="" class="w-10 h-10 object-cover rounded-full">
+    <div th:if="${#strings.contains(profile.savedName, 'https')}">
+      <img th:src="${profile.savedName}" alt="" class="w-10 h-10 object-cover rounded-full">
+    </div>
+    <div th:if="!${#strings.contains(profile.savedName, 'https')}">
+      <img th:src="|/attach/${profile.savedName}|" alt="" class="w-10 h-10 object-cover rounded-full">
+    </div>
   </th:block>
 </th:block>
 </body>

--- a/src/main/resources/templates/profiles/index.html
+++ b/src/main/resources/templates/profiles/index.html
@@ -18,7 +18,12 @@
     <div class="mb-2 flex items-center justify-center">
       <th:block th:if="${profile.savedName == null}">
         <th:block th:if="${profile.image != null and profile.image != ''}">
-          <img th:src="${profile.image}" alt="" class="w-32 h-32 object-cover rounded-full">
+          <div th:if="${#strings.contains(profile.image, 'https')}">
+            <img th:src="${profile.image}" alt="" class="w-32 h-32 object-cover rounded-full">
+          </div>
+          <div th:if="!${#strings.contains(profile.image, 'https')}">
+            <img th:src="|/attach/${profile.image}|" alt="" class="w-32 h-32 object-cover rounded-full">
+          </div>
         </th:block>
         <th:block th:if="${profile.image == null or profile.image == ''}">
           <div class="w-32 h-32 rounded-full inline-flex items-center justify-center bg-gray-200 text-gray-900 text-lg font-bold"
@@ -26,7 +31,12 @@
         </th:block>
       </th:block>
       <th:block th:if="${profile.savedName != null}">
-        <img th:src="|/attach/${profile.savedName}|" alt="" class="w-32 h-32 object-cover rounded-full">
+        <div th:if="${#strings.contains(profile.savedName, 'https')}">
+          <img th:src="${profile.savedName}" alt="" class="w-32 h-32 object-cover rounded-full">
+        </div>
+        <div th:if="!${#strings.contains(profile.savedName, 'https')}">
+          <img th:src="|/attach/${profile.savedName}|" alt="" class="w-32 h-32 object-cover rounded-full">
+        </div>
       </th:block>
     </div>
     <h1 class="text-3xl font-bold" th:text="${profile.nickname}">프로필 이름</h1>

--- a/src/test/java/com/pinterest/controller/BoardControllerTest.java
+++ b/src/test/java/com/pinterest/controller/BoardControllerTest.java
@@ -233,7 +233,8 @@ class BoardControllerTest {
                 createMemberDto(),
                 "title",
                 "content",
-                "hashtag"
+                "hashtag",
+                "image"
         );
     }
 }

--- a/src/test/java/com/pinterest/controller/ProfilesControllerTest.java
+++ b/src/test/java/com/pinterest/controller/ProfilesControllerTest.java
@@ -139,7 +139,8 @@ class ProfilesControllerTest {
                 createMemberDto(),
                 "title",
                 "content",
-                "hashtag"
+                "hashtag",
+                "image"
         );
     }
 

--- a/src/test/java/com/pinterest/service/ArticleServiceTest.java
+++ b/src/test/java/com/pinterest/service/ArticleServiceTest.java
@@ -141,7 +141,7 @@ class ArticleServiceTest {
         given(boardRepository.getReferenceById(dto.getBoardId())).willReturn(createBoard());
         given(memberRepository.findByEmail(dto.getMemberDto().getEmail())).willReturn(Optional.of(createMember()));
         given(articleRepository.save(any(Article.class))).willReturn(createArticle());
-        given(fileService.saveFile(file)).willReturn(createFile());
+        given(fileService.upload(file)).willReturn(createFile());
 
         // When
         sut.saveArticle(file, dto);
@@ -150,7 +150,7 @@ class ArticleServiceTest {
         then(boardRepository).should().getReferenceById(dto.getBoardId());
         then(memberRepository).should().findByEmail(dto.getMemberDto().getEmail());
         then(articleRepository).should().save(any(Article.class));
-        then(fileService).should().saveFile(file);
+        then(fileService).should().upload(file);
     }
 
     @Test

--- a/src/test/java/com/pinterest/service/ProfileServiceTest.java
+++ b/src/test/java/com/pinterest/service/ProfileServiceTest.java
@@ -42,7 +42,7 @@ class ProfileServiceTest {
         MemberDto dto = createMemberDto();
         MockMultipartFile file = new MockMultipartFile("fileName", "test.png", "image/*", "test file".getBytes(StandardCharsets.UTF_8));
         given(memberRepository.getReferenceById(dto.getId())).willReturn(member);
-        given(fileService.saveFile(file)).willReturn(any(FileEntity.class));
+        given(fileService.upload(file)).willReturn(any(FileEntity.class));
 
         // When
         sut.updateMember(dto.getId(), dto, file);


### PR DESCRIPTION
- AWS S3 파일 저장, 삭제 기능 구현
- 관련된 테스트 코드 수정
- 핀 삭제 시 파일도 삭제하도록 구현
- 보드 이름 중복을 회원별로 검사하도록 수정

This is closes #78 